### PR TITLE
Fix broken rockspec

### DIFF
--- a/rockspecs/chance-1.0-0.rockspec
+++ b/rockspecs/chance-1.0-0.rockspec
@@ -15,7 +15,7 @@ dependencies = {
     "lua ~= 5.3"
 }
 build = {
-    type = "buildin",
+    type = "builtin",
     modules = {
         tiny = "chance.lua"
     }


### PR DESCRIPTION
Fixes error when trying to install:

```
Error: Failed initializing build back-end for build type 'buildin': module 'luarocks.build.buildin' not found:No LuaRocks module found for luarocks.build.buildin
```
